### PR TITLE
Fix service worker notification initialization

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -5,17 +5,28 @@
 importScripts('https://www.gstatic.com/firebasejs/12.0.0/firebase-app-compat.js');
 importScripts('https://www.gstatic.com/firebasejs/12.0.0/firebase-messaging-compat.js');
 
-(async () => {
-  const firebaseConfig = await fetch('/firebase-config.json').then(res => res.json());
-  firebase.initializeApp(firebaseConfig);
-  const messaging = firebase.messaging();
+// Initialize Firebase synchronously to ensure event listeners are registered
+// during the service worker's initial evaluation. Using async initialization
+// can cause Firebase to miss push event handlers, resulting in registration
+// errors in some browsers.
+const firebaseConfig = {
+  apiKey: 'AIzaSyBmbqYQiEERc8xGn81TYcbHkErB468dDKE',
+  authDomain: 'buzzy-d2b2a.firebaseapp.com',
+  projectId: 'buzzy-d2b2a',
+  storageBucket: 'buzzy-d2b2a.firebasestorage.app',
+  messagingSenderId: '512369963479',
+  appId: '1:512369963479:web:babd61d660cbd32beadb92'
+};
 
-  console.log('🎯 === FIREBASE MESSAGING SERVICE WORKER INITIALIZED ===');
-  console.log('Firebase config:', firebaseConfig);
-  console.log('Messaging initialized:', !!messaging);
+firebase.initializeApp(firebaseConfig);
+const messaging = firebase.messaging();
 
-  // Handle background messages
-  messaging.onBackgroundMessage((payload) => {
+console.log('🎯 === FIREBASE MESSAGING SERVICE WORKER INITIALIZED ===');
+console.log('Firebase config:', firebaseConfig);
+console.log('Messaging initialized:', !!messaging);
+
+// Handle background messages
+messaging.onBackgroundMessage((payload) => {
     console.log('🎯 === BACKGROUND MESSAGE RECEIVED ===');
     console.log('Payload:', payload);
     console.log('User agent:', navigator.userAgent);
@@ -61,8 +72,7 @@ importScripts('https://www.gstatic.com/firebasejs/12.0.0/firebase-messaging-comp
       .catch((error) => {
         console.error('❌ Error showing notification:', error);
       });
-  });
-})();
+});
 
 // Handle notification clicks
 self.addEventListener('notificationclick', (event) => {

--- a/src/utils/pwaUtils.js
+++ b/src/utils/pwaUtils.js
@@ -54,22 +54,24 @@ export const registerServiceWorkers = async () => {
 // Show update notification to user
 const showUpdateNotification = () => {
   if ('Notification' in window && Notification.permission === 'granted') {
-    new Notification('Buzzy Update Available', {
-      body: 'A new version of Buzzy is available. Refresh the page to update.',
-      icon: '/android/android-launchericon-192-192.png',
-      badge: '/android/android-launchericon-48-48.png',
-      tag: 'buzzy-update',
-      requireInteraction: true,
-      actions: [
-        {
-          action: 'refresh',
-          title: 'Refresh Now'
-        },
-        {
-          action: 'dismiss',
-          title: 'Later'
-        }
-      ]
+    navigator.serviceWorker.ready.then((registration) => {
+      registration.showNotification('Buzzy Update Available', {
+        body: 'A new version of Buzzy is available. Refresh the page to update.',
+        icon: '/android/android-launchericon-192-192.png',
+        badge: '/android/android-launchericon-48-48.png',
+        tag: 'buzzy-update',
+        requireInteraction: true,
+        actions: [
+          {
+            action: 'refresh',
+            title: 'Refresh Now'
+          },
+          {
+            action: 'dismiss',
+            title: 'Later'
+          }
+        ]
+      });
     });
   }
 };


### PR DESCRIPTION
## Summary
- initialize Firebase messaging SW synchronously so event listeners register correctly
- show update notification via service worker registration to avoid Notification API errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689015c9faac83228c87fda4097be8cf