### PR TITLE
fix: ensure messaging reinitializes for token

### DIFF
--- a/src/components/NotificationDiagnostic.jsx
+++ b/src/components/NotificationDiagnostic.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useAuth } from '../contexts/AuthContext.jsx';
 
 const NotificationDiagnostic = () => {
@@ -199,7 +199,7 @@ const NotificationDiagnostic = () => {
   const registerServiceWorker = async () => {
     addLog('🔧 Registering service worker...', 'info');
     try {
-      const registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js', {
+      await navigator.serviceWorker.register('/firebase-messaging-sw.js', {
         scope: '/'
       });
       await navigator.serviceWorker.ready;

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -339,9 +339,19 @@ export const requestNotificationPermission = async () => {
 export const getNotificationToken = async () => {
   try {
     console.log('🔔 === NOTIFICATION TOKEN DEBUG START ===');
-    
+
+    // Ensure messaging is available. The initial initialization can fail in
+    // some environments (for example when the module loads before Firebase
+    // features are fully supported in the browser). If it's missing, attempt
+    // to reinitialize it here so token generation can proceed.
     if (!messaging) {
-      throw new Error('Firebase messaging not initialized');
+      try {
+        messaging = getMessaging(app);
+        console.log('Firebase messaging reinitialized successfully');
+      } catch (error) {
+        console.error('Failed to reinitialize Firebase messaging:', error);
+        throw new Error('Firebase messaging not initialized');
+      }
     }
     
     // Check notification permission


### PR DESCRIPTION
## Summary
- retry Firebase messaging init during token requests
- clean notification diagnostic utility

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893b4da7d3c83228fee3bc79c9f5839